### PR TITLE
Add server error handler. Fail if address is already in use.

### DIFF
--- a/problems/node-debug/index.js
+++ b/problems/node-debug/index.js
@@ -53,7 +53,7 @@ module.exports = function () {
 
       server.on("close", function () {
         t.notOk(
-          out.match(/parse error/) || err.match(/parse error/),
+          out.match(/parse error/) || err.match(/parse error/) || err.match(/EADDRINUSE/),
           "request was made successfully"
         );
 

--- a/problems/node-debug/server.js
+++ b/problems/node-debug/server.js
@@ -1,3 +1,7 @@
 var createServer = require("http").createServer;
 var server = createServer(function (req, res) { res.end("hello"); });
+server.on("error", function(err) {
+  console.error(err.stack);
+  process.exit(1);
+});
 server.listen(9876, function () { console.log("listening"); });


### PR DESCRIPTION
If you have the server running and then run `bug-clinic verify client.js` it always returns a PASS. 

Currently it throws the error:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: listen EADDRINUSE
```

Then proceeds to indicate success (regardless of your solution):

```
# PASS

Your solution to SCAN passed!
```

I've handled this particular error.
