### PR TITLE
bump bunyan to avoid dtrace-provider issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "adventure": "^2.4.0",
     "adventure-verify": "^2.1.1",
-    "bunyan": "^0.23.1",
+    "bunyan": "^1.8.1",
     "concat-stream": "^1.4.6",
     "default-pager": "^1.0.1",
     "eslint": "^0.6.2",


### PR DESCRIPTION
@othiym23 currently experiencing issues while installing on node v{4,5,6}, this fixes it.

Thanks
